### PR TITLE
Add baseurl Shortcode

### DIFF
--- a/content/post/personal/life/christmas-2015.md
+++ b/content/post/personal/life/christmas-2015.md
@@ -17,7 +17,7 @@ if I know they don't fully understand everything.
 
 Before we went down, we had the girls get their Christmas Jamies on!
 
-![Evelyn and Ruby in Christmas Jamies](/assets/uploads/2015/12/27/EvelynAndRuby-ChristmasJamies.jpg)
+![Evelyn and Ruby in Christmas Jamies]({{< baseurl >}}assets/uploads/2015/12/27/EvelynAndRuby-ChristmasJamies.jpg)
 
 When we went downstairs there wasn't much ceremony to it at all. No one "played
 Santa" as Ralphie and Randy would say. I mean, Evelyn (our oldest) is just
@@ -28,7 +28,7 @@ Birthday.
 
 **Ruby**
 <div class="img-container">
-![Ruby playing with her new toys](/assets/uploads/2015/12/27/Ruby-Presents.jpg)
+![Ruby playing with her new toys]({{< baseurl >}}assets/uploads/2015/12/27/Ruby-Presents.jpg)
 <small>
     Ruby loved her play table. She can stand and make lots and lots of noise!
 </small>
@@ -36,12 +36,12 @@ Birthday.
 
 **Evelyn**
 <div class="img-container">
-![Evelyn Opening a present](/assets/uploads/2015/12/27/EvelynOpeningPresent.jpg)
+![Evelyn Opening a present]({{< baseurl >}}assets/uploads/2015/12/27/EvelynOpeningPresent.jpg)
 <small>
     Evelyn was shy about opening presents at first, but really got into it as
     the morning wore on.
 </small>
-![Evelyn playing with her train set](/assets/uploads/2015/12/27/EvelynTrains.jpg)
+![Evelyn playing with her train set]({{< baseurl >}}assets/uploads/2015/12/27/EvelynTrains.jpg)
 <small>
     Probably her favorite present: A train set!
 </small>
@@ -60,7 +60,7 @@ will tell if we can do it again next year!
 
 P.S. Due to my own presents there will be a lot of Raspberry Pi posts coming...
 
-![Raspberry Pi with 2.8 inch TFT display](/assets/uploads/RaspberryPi2-2.8-TFT-Adafruit.jpg)
+![Raspberry Pi with 2.8 inch TFT display]({{< baseurl >}}assets/uploads/RaspberryPi2-2.8-TFT-Adafruit.jpg)
 
 <div class="img-container">
 

--- a/content/post/personal/life/resolutions-2016.md
+++ b/content/post/personal/life/resolutions-2016.md
@@ -18,7 +18,7 @@ blog to see. That's who/what this post is for.
 I wanted to make my resolutions less about "I want to lose weight", and more
 focused on programming, open source, and this blog.
 
-![Don't let your dreams be dreams](/assets/uploads/2016/01/shia.jpg)
+![Don't let your dreams be dreams]({{< baseurl >}}assets/uploads/2016/01/shia.jpg)
 <small>Some motivation from shia</small>
 
 ### 1. Blog (at least) Weekly

--- a/content/post/programming/tools/powershell-debugging-in-vscode.md
+++ b/content/post/programming/tools/powershell-debugging-in-vscode.md
@@ -28,10 +28,10 @@ just have to open a PowerShell script, hit `F5` and away you go!
 Here's the steps:
 
 ### 1. Open the Debug Tab
-![Debug Tab](/assets/uploads/2016/04/vscode_debug_tab.png)
+![Debug Tab]({{< baseurl >}}assets/uploads/2016/04/vscode_debug_tab.png)
 
 ### 2. Click the gear and select "PowerShell" from the dropdown
-![Select PowerShell](/assets/uploads/2016/04/vscode_debug_select_powershell.png)
+![Select PowerShell]({{< baseurl >}}assets/uploads/2016/04/vscode_debug_select_powershell.png)
 
 VSCode has been awesome to work with (I'm using it to write this post!). Having
 a built in debugger with a light-weight and extensible text editor has been
@@ -40,7 +40,7 @@ the left of the line number (just like in any good debugging tool). Here's what
 it looks like when you are actually debugging (this is actually my PowerShell
 profile):
 
-![Debugging](/assets/uploads/2016/04/vscode_debugging.png)
+![Debugging]({{< baseurl >}}assets/uploads/2016/04/vscode_debugging.png)
 
 What other cool things do you love about VSCode?
 

--- a/content/post/raspberry-pi/torrent-machine-and-network-share.md
+++ b/content/post/raspberry-pi/torrent-machine-and-network-share.md
@@ -31,16 +31,16 @@ Then I made sure my SD card was clean and ready to flash. I like to use the
 Windows CLI tool `diskpart`. You can see pretty simply the steps I took from the
 image below:
 
-![Cleaning my SD Card](/assets/uploads/2016/01/clean_disk_windows_powershell.png)
+![Cleaning my SD Card]({{< baseurl >}}assets/uploads/2016/01/clean_disk_windows_powershell.png)
 
 Once my SD Card was clean, I formatted it:
 
-![Formatting my SD Card](/assets/uploads/2016/01/new_simple_volume_disk_management.png)
+![Formatting my SD Card]({{< baseurl >}}assets/uploads/2016/01/new_simple_volume_disk_management.png)
 
 It doesn't matter what format you use because you're going to reformat it when
 you write the image to the SD card (I use [Win32DiskImager](3)):
 
-![Write Image to SD Card](/assets/uploads/2016/01/write_img.png)
+![Write Image to SD Card]({{< baseurl >}}assets/uploads/2016/01/write_img.png)
 
 ### Notes
 

--- a/content/post/site-updates/https.md
+++ b/content/post/site-updates/https.md
@@ -20,7 +20,7 @@ hosting using it couldn't be easier.
 All you have to do is [set up your custom domain][2] to point to your GitHub pages
 site, and then update the settings on your repo to look like mine:
 
-![GitHub Pages Settings](/assets/uploads/2018/05/GitHubPagesHTTPSConfig.png)
+![GitHub Pages Settings]({{< baseurl >}}assets/uploads/2018/05/GitHubPagesHTTPSConfig.png)
 
 If, like me, you're already using a custom domain on GitHub pages then you have
 to follow these simple steps to enable HTTPS:

--- a/layouts/shortcodes/baseurl.html
+++ b/layouts/shortcodes/baseurl.html
@@ -1,0 +1,1 @@
+{{ .Page.Site.BaseURL }}


### PR DESCRIPTION
The baseurl Shortcode will allow me to reference the baseurl for the
site in content pages. This enables me to link securely to images in
prod but still use plain `http` in dev.